### PR TITLE
Add IaC configs for storage bucket and BQ dataset

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "6.21.0"
+    }
+  }
+  cloud { 
+    organization = "Personal-Projects-cpwill"
+    workspaces { 
+      name = "DE_Zoomcamp_Project" 
+    } 
+  }
+}
+
+provider "google" {
+  project     = var.project
+  region      = var.region
+}
+
+resource "google_storage_bucket" "web_events_bucket" {
+  name          = "web-events-bucket"
+  location      = var.region
+  force_destroy = true
+  
+  # how long to wait for a multipart (chunked) upload
+  lifecycle_rule {
+    condition {
+      age = 1 #in days
+    }
+    action {
+      type = "AbortIncompleteMultipartUpload"
+    }
+  }
+}
+
+resource "google_bigquery_dataset" "web_events_dataset" {
+  dataset_id    = "web_events_dataset"
+  description   = "Dataset for webalytics pipeline project"
+  location      = var.region
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,16 @@
+variable "project" {
+  description = "GCP Project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "Project Region"
+  default     = "us-central1"
+  type        = string
+}
+
+variable "zone" {
+  description = "Project Zone"
+  default     = "us-central1-a"
+  type        = string
+}


### PR DESCRIPTION
# Description

Applying these configs via Terraform will set up the GCS bucket to sink the event logs into, and a BigQuery Dataset where the data warehouse will be built. 