### PR TITLE
Make data test for listen events less restrictive

### DIFF
--- a/pipeline/transforms/models/core/facts.yml
+++ b/pipeline/transforms/models/core/facts.yml
@@ -11,6 +11,7 @@ models:
           combination_of_columns:
             - event_datetime
             - pk_user
+            - pk_song
           severity: error
     columns:
       - name: event_datetime

--- a/pipeline/transforms/models/staging/schema.yml
+++ b/pipeline/transforms/models/staging/schema.yml
@@ -61,6 +61,7 @@ models:
           combination_of_columns:
             - event_datetime
             - user_id
+            - prev_level
           severity: error
     columns:
       - name: event_datetime
@@ -96,12 +97,6 @@ models:
       Staging table for listen event data, which refer to a user listening to a song.
     config:
       tags: "staging"
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - event_datetime
-            - user_id
-          severity: error
     columns:
       - name: event_datetime
         data_type: timestamp


### PR DESCRIPTION
Data tests were causing builds to fail as they were too restrictive and did not account for the case where a user may be listening to multiple songs at the same time (e.g. on different devices). This commit fixes the tests to account for this scenario.