### PR TITLE
fix: standardise quoted song names

### DIFF
--- a/pipeline/transforms/models/core/dim_songs.sql
+++ b/pipeline/transforms/models/core/dim_songs.sql
@@ -3,7 +3,7 @@
 WITH distinct_songs AS (
     SELECT DISTINCT
         artist,
-        title,
+        REGEXP_REPLACE(title, r'([^\p{ASCII}]+)|(")', '') AS title,
         ROUND(duration, 2) AS duration,
         genre
     FROM

--- a/pipeline/transforms/models/staging/stg_listen_events.sql
+++ b/pipeline/transforms/models/staging/stg_listen_events.sql
@@ -22,7 +22,7 @@ SELECT
     COALESCE(city, "NO CITY") AS city,
     COALESCE(state, "NO STATE") AS state,
     level,
-    song,
+    REGEXP_REPLACE(song, r'([^\p{ASCII}]+)|(")', '') AS song,
     artist,
     ROUND(duration, 2) as duration
 FROM


### PR DESCRIPTION
Some songs had quotes being doubled "" in listen events but single " in the song file, which led to inconsistency in joins. This commit fixes it by removing quotes from all song names.